### PR TITLE
feat: model dropdown + selected model used in apps

### DIFF
--- a/File_Q&A.py
+++ b/File_Q&A.py
@@ -4,7 +4,7 @@ import json
 from components.Sidebar import sidebar
 from shared import constants
 
-api_key = sidebar()
+api_key, selected_model = sidebar(constants.OPENROUTER_DEFAULT_CHAT_MODEL)
 
 st.title("📝 File Q&A with OpenRouter")
 uploaded_file = st.file_uploader("Upload an article", type="txt")
@@ -30,7 +30,7 @@ if uploaded_file and question and api_key:
     openai.api_key = api_key
     openai.api_base = constants.OPENROUTER_API_BASE
     response = openai.ChatCompletion.create(
-        model=constants.OPENROUTER_DEFAULT_INSTRUCT_MODEL,
+        model=selected_model,
         messages=[context_message, question_message],
         headers={
             "HTTP-Referer": constants.OPENROUTER_REFERER

--- a/components/Sidebar.py
+++ b/components/Sidebar.py
@@ -1,27 +1,53 @@
 import streamlit as st
 import webbrowser
+import requests
+import json
+from shared import constants
 
+# Get available models from the API
+def get_available_models():
+    try:
+        response = requests.get(constants.OPENROUTER_API_BASE + '/models')
+        response.raise_for_status()
+        models = json.loads(response.text)["data"]
+        return [model['id'] for model in models]
+    except requests.exceptions.RequestException as e:
+        st.error(f"Error getting models from API: {e}")
+        return []
 
-def sidebar():
+# Handle the model selection process
+def handle_model_selection(available_models, selected_model, default_model):
+    # Determine the index of the selected model
+    if selected_model and selected_model in available_models:
+        selected_index = available_models.index(selected_model)
+    else:
+        selected_index = available_models.index(default_model)
+    selected_model = st.selectbox('Select a model', available_models, index=selected_index)
+    return selected_model
+
+def sidebar(default_model):
     with st.sidebar:
         params = st.experimental_get_query_params()
-        api_key = params.get("api_key", [""])[0] or st.session_state.get("api_key")
+        # not storing sensitive api_key in query params
+        api_key = st.session_state.get("api_key")
+        selected_model = params.get("model", [None])[0] or st.session_state.get("model", None)
         if not api_key:
             if st.button("Connect OpenRouter"):
                 webbrowser.open(
                     "https://openrouter.ai/account?callback_url=http://localhost:8501",
                     new=0,
                 )
-            # link = "[Connect OpenRouter](https://openrouter.ai/account?callback_url=http://localhost:8501)"
-            # st.markdown(link, unsafe_allow_html=True)
-            # api_key = st.text_input("Or enter a key manually:")
-        else:
-            st.session_state["api_key"] = api_key
+        available_models = get_available_models()
+        selected_model = handle_model_selection(available_models, selected_model, default_model)
+        st.session_state["model"] = selected_model
+        st.experimental_set_query_params(model=selected_model)
+
+        if api_key:
             st.text("Connected to OpenRouter")
             if st.button("Log out"):
                 del st.session_state["api_key"]
                 st.experimental_rerun()
-            st.experimental_set_query_params()
-        "[View the source code](https://github.com/streamlit/llm-examples/blob/main/Chatbot.py)"
-        "[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/streamlit/llm-examples?quickstart=1)"
-    return api_key
+        st.markdown("[View the source code](https://github.com/streamlit/llm-examples/blob/main/Chatbot.py)")
+        st.markdown("[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/streamlit/llm-examples?quickstart=1)")
+        
+    return api_key, selected_model

--- a/pages/1_Chatbot.py
+++ b/pages/1_Chatbot.py
@@ -5,7 +5,7 @@ from components.Sidebar import sidebar
 import json
 from shared import constants
 
-api_key = sidebar()
+api_key, selected_model = sidebar(constants.OPENROUTER_DEFAULT_CHAT_MODEL)
 
 st.title("💬 Streamlit GPT")
 if "messages" not in st.session_state:
@@ -34,7 +34,7 @@ if user_input and api_key:
     openai.api_key = api_key
     openai.api_base = constants.OPENROUTER_API_BASE
     response = openai.ChatCompletion.create(
-        model=constants.OPENROUTER_DEFAULT_CHAT_MODEL,
+        model=selected_model,
         messages=st.session_state.messages,
         headers={
             "HTTP-Referer": constants.OPENROUTER_REFERER

--- a/pages/2_Langchain_Quickstart.py
+++ b/pages/2_Langchain_Quickstart.py
@@ -5,7 +5,7 @@ from shared import constants
 
 st.title('🦜🔗 Langchain Quickstart App')
 
-api_key = sidebar()
+api_key, selected_model = sidebar(constants.OPENROUTER_DEFAULT_CHAT_MODEL)
 
 def generate_response(input_text):
   llm = OpenAI(

--- a/pages/2_Langchain_Quickstart.py
+++ b/pages/2_Langchain_Quickstart.py
@@ -10,7 +10,7 @@ api_key, selected_model = sidebar(constants.OPENROUTER_DEFAULT_CHAT_MODEL)
 def generate_response(input_text):
   llm = OpenAI(
     temperature=0.7, 
-    model=constants.OPENROUTER_DEFAULT_CHAT_MODEL,
+    model=selected_model,
     openai_api_key=api_key,
     openai_api_base=constants.OPENROUTER_API_BASE,
     headers={"HTTP-Referer": constants.OPENROUTER_REFERER}

--- a/pages/3_Langchain_PromptTemplate.py
+++ b/pages/3_Langchain_PromptTemplate.py
@@ -6,12 +6,12 @@ from shared import constants
 
 st.title('🦜🔗 Langchain - Blog Outline Generator App')
 
-api_key = sidebar()
+api_key, selected_model = sidebar(constants.OPENROUTER_DEFAULT_INSTRUCT_MODEL)
 
 def blog_outline(topic):
   # Instantiate LLM model
   llm = OpenAI(
-    model_name=constants.OPENROUTER_DEFAULT_INSTRUCT_MODEL,
+    model_name=selected_model,
     openai_api_key=api_key,
     openai_api_base=constants.OPENROUTER_API_BASE,
     headers={"HTTP-Referer": constants.OPENROUTER_REFERER}

--- a/pages/4_Langchain_Search.py
+++ b/pages/4_Langchain_Search.py
@@ -6,7 +6,7 @@ from langchain.agents import AgentType
 from components.Sidebar import sidebar
 from shared import constants
 
-api_key = sidebar()
+api_key, selected_model = sidebar(constants.OPENROUTER_DEFAULT_CHAT_MODEL)
 
 with st.sidebar:
     serper_api_key = st.text_input('Serper API Key',key='langchain_search_api_key_serper')
@@ -23,7 +23,7 @@ if question:
         st.info("Please connect with OpenRouter to continue.")
     elif serper_api_key and api_key:
         llm = ChatOpenAI(
-            model_name=constants.OPENROUTER_DEFAULT_CHAT_MODEL,    
+            model_name=selected_model,    
             openai_api_key=api_key,
             openai_api_base=constants.OPENROUTER_API_BASE,
             headers={"HTTP-Referer": constants.OPENROUTER_REFERER}


### PR DESCRIPTION
### Related Linear Issue
[OPE-83](https://linear.app/openrouter/issue/OPE-83/add-a-dropdown-widget-to-select-an-openrouter-model-in-the-sidebar) - Model Dropdown Widget
### Changes
- Added a model dropdown widget to the sidebar component. Pulling list of models from the OpenRouter API. 
- Chose to only store the API key in session_state and not in the query params as it is sensitive. 
- Apps now grab selected model from the sidebar and use it for subsequent requests. The sidebar component takes one argument specifying the default model for that app.
### Additional Notes
- Requires more testing once implicit auth is done to verify full functionality
- Feedback requested on decisions on where to store api key and selected model (query params, session state, both)